### PR TITLE
Status reserva incorreto

### DIFF
--- a/app/admin/reservas/page.tsx
+++ b/app/admin/reservas/page.tsx
@@ -1757,8 +1757,9 @@ export default function ReservesPage() {
                                         return areaName || '';
                                       };
                                       
-                                      const isSeuJustinoReservas = reservation.establishment_id === 1 || 
-                                        ((reservation as any).establishment_name || '').toLowerCase().includes('seu justino');
+                                      const establishmentName = ((reservation as any).establishment_name || '').toLowerCase();
+                                      const isSeuJustinoReservas = establishmentName.includes('seu justino') &&
+                                        !establishmentName.includes('pracinha');
                                       
                                       const finalAreaName = isSeuJustinoReservas && reservation.table_number
                                         ? getSeuJustinoAreaName(reservation.table_number, reservation.area_name, reservation.area_id)

--- a/app/components/AllocateTableModal.tsx
+++ b/app/components/AllocateTableModal.tsx
@@ -70,6 +70,14 @@ export default function AllocateTableModal({
     return reservationName.includes(selectedName) || selectedName.includes(reservationName);
   };
 
+  const normalizeReservationDate = (dateStr?: string | null) => {
+    if (!dateStr) return null;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+    const d = new Date(dateStr);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toISOString().split('T')[0];
+  };
+
   // Subáreas específicas do Seu Justino
   const seuJustinoSubareas = [
     { key: 'lounge-aquario-spaten', area_id: 1, label: 'Lounge Aquario Spaten', tableNumbers: ['210'], capacity: 8 },
@@ -149,8 +157,12 @@ export default function AllocateTableModal({
                   ? reservationsData.reservations 
                   : [];
                 const reservationsForEstablishment = allReservations.filter(matchesSelectedEstablishment);
+                const reservationsForDate = reservationsForEstablishment.filter(
+                  (reservation: any) =>
+                    normalizeReservationDate(reservation.reservation_date) === entry.preferred_date
+                );
                 
-                const activeReservations = reservationsForEstablishment.filter((reservation: any) => {
+                const activeReservations = reservationsForDate.filter((reservation: any) => {
                   const status = String(reservation.status || '').toUpperCase();
                   return status !== 'CANCELADA' && 
                          status !== 'CANCELADO' &&

--- a/app/components/AllocateTableModal.tsx
+++ b/app/components/AllocateTableModal.tsx
@@ -48,6 +48,27 @@ export default function AllocateTableModal({
     !(establishment.name || '').toLowerCase().includes('pracinha')
   );
   const isPracinha = establishment && (establishment.name || '').toLowerCase().includes('pracinha');
+  const normalizeEstablishmentName = (name?: string | null) => (name || '').toLowerCase().trim();
+  const matchesSelectedEstablishment = (reservation: any): boolean => {
+    if (!establishment) return true;
+    const selectedId = Number(establishment.id);
+    const reservationId = reservation?.establishment_id;
+    if (reservationId != null && !Number.isNaN(Number(reservationId))) {
+      return Number(reservationId) === selectedId;
+    }
+    const selectedName = normalizeEstablishmentName(establishment.name);
+    const reservationName = normalizeEstablishmentName(
+      reservation?.establishment_name || reservation?.place_name || reservation?.establishment
+    );
+    if (!selectedName || !reservationName) return false;
+    const selectedIsJustino = selectedName.includes('seu justino') && !selectedName.includes('pracinha');
+    const selectedIsPracinha = selectedName.includes('pracinha');
+    const reservationIsJustino = reservationName.includes('seu justino') && !reservationName.includes('pracinha');
+    const reservationIsPracinha = reservationName.includes('pracinha');
+    if (selectedIsJustino) return reservationIsJustino;
+    if (selectedIsPracinha) return reservationIsPracinha;
+    return reservationName.includes(selectedName) || selectedName.includes(reservationName);
+  };
 
   // Subáreas específicas do Seu Justino
   const seuJustinoSubareas = [
@@ -127,13 +148,7 @@ export default function AllocateTableModal({
                 const allReservations = Array.isArray(reservationsData.reservations) 
                   ? reservationsData.reservations 
                   : [];
-                const establishmentId = establishment?.id ? Number(establishment.id) : null;
-                const reservationsForEstablishment = establishmentId
-                  ? allReservations.filter((reservation: any) => {
-                      if (reservation.establishment_id == null) return true;
-                      return Number(reservation.establishment_id) === establishmentId;
-                    })
-                  : allReservations;
+                const reservationsForEstablishment = allReservations.filter(matchesSelectedEstablishment);
                 
                 const activeReservations = reservationsForEstablishment.filter((reservation: any) => {
                   const status = String(reservation.status || '').toUpperCase();

--- a/app/components/AllocateTableModal.tsx
+++ b/app/components/AllocateTableModal.tsx
@@ -127,10 +127,19 @@ export default function AllocateTableModal({
                 const allReservations = Array.isArray(reservationsData.reservations) 
                   ? reservationsData.reservations 
                   : [];
+                const establishmentId = establishment?.id ? Number(establishment.id) : null;
+                const reservationsForEstablishment = establishmentId
+                  ? allReservations.filter((reservation: any) => {
+                      if (reservation.establishment_id == null) return true;
+                      return Number(reservation.establishment_id) === establishmentId;
+                    })
+                  : allReservations;
                 
-                const activeReservations = allReservations.filter((reservation: any) => {
+                const activeReservations = reservationsForEstablishment.filter((reservation: any) => {
                   const status = String(reservation.status || '').toUpperCase();
                   return status !== 'CANCELADA' && 
+                         status !== 'CANCELADO' &&
+                         status !== 'CANCEL' &&
                          status !== 'CANCELED' && 
                          status !== 'COMPLETED' &&
                          status !== 'FINALIZADA';
@@ -160,10 +169,16 @@ export default function AllocateTableModal({
                   }
                 });
                 
-                fetched = fetched.map(table => ({
-                  ...table,
-                  is_reserved: reservedTableNumbers.has(String(table.table_number)) || table.is_reserved
-                }));
+                fetched = fetched.map(table => {
+                  const isReservedByOverlap = reservedTableNumbers.has(String(table.table_number));
+                  const shouldIgnoreEndpointReserved = isSeuJustino || isPracinha;
+                  return {
+                    ...table,
+                    is_reserved: shouldIgnoreEndpointReserved
+                      ? isReservedByOverlap
+                      : (isReservedByOverlap || table.is_reserved)
+                  };
+                });
               }
             } catch (err) {
               console.error('Erro ao verificar disponibilidade:', err);

--- a/app/components/ReservationDetailsModal.tsx
+++ b/app/components/ReservationDetailsModal.tsx
@@ -537,11 +537,6 @@ export default function ReservationDetailsModal({
     return areaName || null;
   };
 
-  // Detectar se é Seu Justino baseado no establishment_id ou nome
-  const isSeuJustino = (reservation as any).establishment_id === 1 || 
-    ((reservation as any).establishment_name?.toLowerCase().includes('seu justino') &&
-     !(reservation as any).establishment_name?.toLowerCase().includes('pracinha'));
-  
   const derivedAreaName = getSubareaLabel(
     (reservation as any).table_number, 
     reservation.area_name, 

--- a/app/components/ReservationModal.tsx
+++ b/app/components/ReservationModal.tsx
@@ -168,6 +168,14 @@ export default function ReservationModal({
     return reservationName.includes(selectedName) || selectedName.includes(reservationName);
   };
 
+  const normalizeReservationDate = (dateStr?: string | null) => {
+    if (!dateStr) return null;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+    const d = new Date(dateStr);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toISOString().split('T')[0];
+  };
+
   const getMaxBirthdate = () => {
     const d = new Date();
     d.setFullYear(d.getFullYear() - 18);
@@ -450,10 +458,14 @@ export default function ReservationModal({
                 ? reservationsData.reservations 
                 : [];
               const reservationsForEstablishment = confirmedReservations.filter(matchesSelectedEstablishment);
+              const reservationsForDate = reservationsForEstablishment.filter(
+                (reservation: any) =>
+                  normalizeReservationDate(reservation.reservation_date) === formData.reservation_date
+              );
                 
                 // Criar um Set com os números das mesas que têm reserva confirmada em qualquer horário
                 const reservedTableNumbers = new Set<string>();
-                reservationsForEstablishment.forEach((reservation: any) => {
+              reservationsForDate.forEach((reservation: any) => {
                   if (reservation.table_number) {
                     // Mesas podem ser múltiplas (separadas por vírgula)
                     const tables = String(reservation.table_number).split(',');
@@ -522,10 +534,14 @@ export default function ReservationModal({
                   ? reservationsData.reservations
                   : [];
                 const reservationsForEstablishment = allReservations.filter(matchesSelectedEstablishment);
+                const reservationsForDate = reservationsForEstablishment.filter(
+                  (reservation: any) =>
+                    normalizeReservationDate(reservation.reservation_date) === formData.reservation_date
+                );
                 
                 // Filtrar apenas reservas que ocupam a mesa (excluir canceladas/finalizadas em qualquer variação)
                 // CRÍTICO: Só considerar reservas que realmente bloqueiam a mesa
-                const activeReservations = reservationsForEstablishment.filter((reservation: any) => {
+                const activeReservations = reservationsForDate.filter((reservation: any) => {
                   const status = String(reservation.status || '').trim().toLowerCase();
                   // Status que NÃO bloqueiam mesa (lista completa)
                   const nonBlocking = new Set([
@@ -970,8 +986,12 @@ export default function ReservationModal({
             ? reservationsData.reservations
             : [];
           const reservationsForEstablishment = allReservations.filter(matchesSelectedEstablishment);
+          const reservationsForDate = reservationsForEstablishment.filter(
+            (reservation: any) =>
+              normalizeReservationDate(reservation.reservation_date) === formData.reservation_date
+          );
           
-          const activeReservations = reservationsForEstablishment.filter((reservation: any) => {
+          const activeReservations = reservationsForDate.filter((reservation: any) => {
             const status = String(reservation.status || '').trim().toLowerCase();
             const nonBlocking = new Set([
               'cancelada', 'cancelado', 'cancelled', 'canceled', 'cancel',
@@ -1203,10 +1223,14 @@ export default function ReservationModal({
               const checkData = await checkReservationsResponse.json();
               const existingReservations = Array.isArray(checkData.reservations) ? checkData.reservations : [];
               const reservationsForEstablishment = existingReservations.filter(matchesSelectedEstablishment);
+              const reservationsForDate = reservationsForEstablishment.filter(
+                (reservation: any) =>
+                  normalizeReservationDate(reservation.reservation_date) === formData.reservation_date
+              );
               
               // Verificar se há reserva no mesmo giro
               const giro = getGiroFromTime(formData.reservation_date, reservation_time);
-              const hasConflict = reservationsForEstablishment.some((r: any) => {
+              const hasConflict = reservationsForDate.some((r: any) => {
                 if (r.status === 'CANCELADA' || r.status === 'canceled' || r.status === 'completed') return false;
                 const rGiro = getGiroFromTime(formData.reservation_date, r.reservation_time || '');
                 return giro && rGiro && giro === rGiro;
@@ -1313,9 +1337,13 @@ export default function ReservationModal({
                   ? reservationsData.reservations 
                   : [];
                 const reservationsForEstablishment = confirmedReservations.filter(matchesSelectedEstablishment);
+                const reservationsForDate = reservationsForEstablishment.filter(
+                  (reservation: any) =>
+                    normalizeReservationDate(reservation.reservation_date) === formData.reservation_date
+                );
                 
                 const reservedTableNumbers = new Set<string>();
-                reservationsForEstablishment.forEach((reservation: any) => {
+                reservationsForDate.forEach((reservation: any) => {
                   if (reservation.table_number) {
                     const tables = String(reservation.table_number).split(',');
                     tables.forEach((table: string) => {

--- a/app/components/ReservationModal.tsx
+++ b/app/components/ReservationModal.tsx
@@ -406,7 +406,7 @@ export default function ReservationModal({
           // Cada estabelecimento tem sua própria lógica e NÃO deve interferir nos outros
           
           const estId = establishment?.id ? Number(establishment.id) : null;
-          const isJustinoOrPracinha = estId === 1 || estId === 8;
+          const isJustinoOrPracinha = isSeuJustino || isPracinha;
           
           // 1. PRIMEIRO: Para Justino/Pracinha, SEMPRE resetar is_reserved ANTES de qualquer coisa
           // Isso garante que o valor do endpoint (que bloqueia dia todo) seja ignorado
@@ -819,7 +819,7 @@ export default function ReservationModal({
 
     // 2º giro (BISTRÔ) para Justino/Pracinha: NÃO exigir mesa (vai para espera antecipada/bistrô)
     const estIdForValidation = establishment?.id ? Number(establishment.id) : null;
-    const isJustinoOrPracinhaForValidation = estIdForValidation === 1 || estIdForValidation === 8;
+    const isJustinoOrPracinhaForValidation = isSeuJustino || isPracinha;
     const isSecondGiroBistro = isSecondGiroBistroJustinoPracinha(
       formData.reservation_date,
       formData.reservation_time,
@@ -1282,8 +1282,7 @@ export default function ReservationModal({
           let fetched: RestaurantTable[] = Array.isArray(data.tables) ? data.tables : [];
           
           // Reaplicar travamento de mesas (APENAS Highline, nunca Justino/Pracinha)
-          const estIdForRelease = establishment?.id ? Number(establishment.id) : null;
-          const isJustinoOrPracinhaForRelease = estIdForRelease === 1 || estIdForRelease === 8;
+          const isJustinoOrPracinhaForRelease = isSeuJustino || isPracinha;
           
           if (isHighline && !isJustinoOrPracinhaForRelease && Number(formData.area_id) === 2) {
             try {
@@ -1859,8 +1858,7 @@ export default function ReservationModal({
                           }
                           
                           // REGRA ABSOLUTA: Para Justino/Pracinha, mostrar TODAS as mesas (não filtrar por is_reserved)
-                          const estIdForFilter = establishment?.id ? Number(establishment.id) : null;
-                          const isJustinoOrPracinhaForFilter = estIdForFilter === 1 || estIdForFilter === 8;
+                          const isJustinoOrPracinhaForFilter = isSeuJustino || isPracinha;
                           
                           return tables
                             .filter(t => {

--- a/app/components/ReservationModal.tsx
+++ b/app/components/ReservationModal.tsx
@@ -498,17 +498,24 @@ export default function ReservationModal({
               );
               if (reservationsRes.ok) {
                 const reservationsData = await reservationsRes.json();
-                const allReservations = Array.isArray(reservationsData.reservations) 
-                  ? reservationsData.reservations 
+                const allReservations = Array.isArray(reservationsData.reservations)
+                  ? reservationsData.reservations
                   : [];
+                const establishmentId = establishment?.id ? Number(establishment.id) : null;
+                const reservationsForEstablishment = establishmentId
+                  ? allReservations.filter((reservation: any) => {
+                      if (reservation.establishment_id == null) return true;
+                      return Number(reservation.establishment_id) === establishmentId;
+                    })
+                  : allReservations;
                 
                 // Filtrar apenas reservas que ocupam a mesa (excluir canceladas/finalizadas em qualquer variação)
                 // CRÍTICO: Só considerar reservas que realmente bloqueiam a mesa
-                const activeReservations = allReservations.filter((reservation: any) => {
+                const activeReservations = reservationsForEstablishment.filter((reservation: any) => {
                   const status = String(reservation.status || '').trim().toLowerCase();
                   // Status que NÃO bloqueiam mesa (lista completa)
                   const nonBlocking = new Set([
-                    'cancelada', 'cancelled', 'canceled', 'cancel',
+                    'cancelada', 'cancelado', 'cancelled', 'canceled', 'cancel',
                     'completed', 'concluida', 'concluída', 'concluido', 'concluído',
                     'finalizada', 'finalized', 'finalizado', 'finalizado',
                     'no_show', 'no-show', 'no show',
@@ -950,16 +957,25 @@ export default function ReservationModal({
         );
         if (reservationsRes.ok) {
           const reservationsData = await reservationsRes.json();
-          const allReservations = Array.isArray(reservationsData.reservations) 
-            ? reservationsData.reservations 
+          const allReservations = Array.isArray(reservationsData.reservations)
+            ? reservationsData.reservations
             : [];
+          const establishmentId = establishment?.id ? Number(establishment.id) : null;
+          const reservationsForEstablishment = establishmentId
+            ? allReservations.filter((reservation: any) => {
+                if (reservation.establishment_id == null) return true;
+                return Number(reservation.establishment_id) === establishmentId;
+              })
+            : allReservations;
           
-          const activeReservations = allReservations.filter((reservation: any) => {
+          const activeReservations = reservationsForEstablishment.filter((reservation: any) => {
             const status = String(reservation.status || '').trim().toLowerCase();
             const nonBlocking = new Set([
-              'cancelada', 'cancelled', 'canceled',
-              'completed', 'concluida', 'concluída', 'finalizada', 'finalized',
-              'no_show', 'no-show'
+              'cancelada', 'cancelado', 'cancelled', 'canceled', 'cancel',
+              'completed', 'concluida', 'concluída', 'concluido', 'concluído',
+              'finalizada', 'finalized', 'finalizado',
+              'no_show', 'no-show', 'no show',
+              'espera antecipada'
             ]);
             return !nonBlocking.has(status);
           });

--- a/app/components/ReservationsDayModal.tsx
+++ b/app/components/ReservationsDayModal.tsx
@@ -207,8 +207,9 @@ export default function ReservationsDayModal({
                               return areaName || '';
                             };
                             
-                            const isSeuJustinoDayModal = (reservation as any).establishment_id === 1 || 
-                              (reservation as any).establishment_name?.toLowerCase().includes('seu justino');
+                            const establishmentName = ((reservation as any).establishment_name || '').toLowerCase();
+                            const isSeuJustinoDayModal = establishmentName.includes('seu justino') &&
+                              !establishmentName.includes('pracinha');
                             
                             return isSeuJustinoDayModal && (reservation as any).table_number
                               ? getSeuJustinoAreaName((reservation as any).table_number, reservation.area_name, (reservation as any).area_id)

--- a/app/components/WaitlistModal.tsx
+++ b/app/components/WaitlistModal.tsx
@@ -103,6 +103,27 @@ export default function WaitlistModal({
     !(establishment.name || '').toLowerCase().includes('pracinha')
   );
   const isPracinha = establishment && (establishment.name || '').toLowerCase().includes('pracinha');
+  const normalizeEstablishmentName = (name?: string | null) => (name || '').toLowerCase().trim();
+  const matchesSelectedEstablishment = (reservation: any): boolean => {
+    if (!establishment) return true;
+    const selectedId = Number(establishment.id);
+    const reservationId = reservation?.establishment_id;
+    if (reservationId != null && !Number.isNaN(Number(reservationId))) {
+      return Number(reservationId) === selectedId;
+    }
+    const selectedName = normalizeEstablishmentName(establishment.name);
+    const reservationName = normalizeEstablishmentName(
+      reservation?.establishment_name || reservation?.place_name || reservation?.establishment
+    );
+    if (!selectedName || !reservationName) return false;
+    const selectedIsJustino = selectedName.includes('seu justino') && !selectedName.includes('pracinha');
+    const selectedIsPracinha = selectedName.includes('pracinha');
+    const reservationIsJustino = reservationName.includes('seu justino') && !reservationName.includes('pracinha');
+    const reservationIsPracinha = reservationName.includes('pracinha');
+    if (selectedIsJustino) return reservationIsJustino;
+    if (selectedIsPracinha) return reservationIsPracinha;
+    return reservationName.includes(selectedName) || selectedName.includes(reservationName);
+  };
   
   // Contar mesas bistrô ocupadas na lista de espera
   const bistroTableCount = waitlistEntries.filter(entry => 
@@ -294,13 +315,7 @@ export default function WaitlistModal({
                 const allReservations = Array.isArray(reservationsData.reservations) 
                   ? reservationsData.reservations 
                   : [];
-                const establishmentId = establishment?.id ? Number(establishment.id) : null;
-                const reservationsForEstablishment = establishmentId
-                  ? allReservations.filter((reservation: any) => {
-                      if (reservation.establishment_id == null) return true;
-                      return Number(reservation.establishment_id) === establishmentId;
-                    })
-                  : allReservations;
+                const reservationsForEstablishment = allReservations.filter(matchesSelectedEstablishment);
                 
                 // Filtrar apenas reservas que ocupam a mesa (excluir canceladas e finalizadas)
                 const activeReservations = reservationsForEstablishment.filter((reservation: any) => {

--- a/app/components/WaitlistModal.tsx
+++ b/app/components/WaitlistModal.tsx
@@ -124,6 +124,14 @@ export default function WaitlistModal({
     if (selectedIsPracinha) return reservationIsPracinha;
     return reservationName.includes(selectedName) || selectedName.includes(reservationName);
   };
+
+  const normalizeReservationDate = (dateStr?: string | null) => {
+    if (!dateStr) return null;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+    const d = new Date(dateStr);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toISOString().split('T')[0];
+  };
   
   // Contar mesas bistrô ocupadas na lista de espera
   const bistroTableCount = waitlistEntries.filter(entry => 
@@ -316,9 +324,13 @@ export default function WaitlistModal({
                   ? reservationsData.reservations 
                   : [];
                 const reservationsForEstablishment = allReservations.filter(matchesSelectedEstablishment);
+                const reservationsForDate = reservationsForEstablishment.filter(
+                  (reservation: any) =>
+                    normalizeReservationDate(reservation.reservation_date) === formData.preferred_date
+                );
                 
                 // Filtrar apenas reservas que ocupam a mesa (excluir canceladas e finalizadas)
-                const activeReservations = reservationsForEstablishment.filter((reservation: any) => {
+                const activeReservations = reservationsForDate.filter((reservation: any) => {
                   const status = String(reservation.status || '').toUpperCase();
                   return status !== 'CANCELADA' && 
                          status !== 'CANCELADO' &&

--- a/app/reservar/ReservationForm.tsx
+++ b/app/reservar/ReservationForm.tsx
@@ -87,8 +87,8 @@ const detectAndCreateBirthdayGuestList = async (reservationId: number, payload: 
     const reservationDate = new Date(`${payload.reservation_date}T00:00:00`);
     const dayOfWeek = reservationDate.getDay(); // Domingo = 0, Sexta = 5, Sábado = 6
     const isWeekend = dayOfWeek === 5 || dayOfWeek === 6; // Sexta ou Sábado
-    const isHighLine = payload.establishment_id === 1;
     const nameLower = (establishmentName || '').toLowerCase();
+    const isHighLine = nameLower.includes('high');
     const isReservaRooftop = nameLower.includes('reserva rooftop') || nameLower.includes('rooftop');
     const isLargeGroup = payload.number_of_people >= 4;
     
@@ -910,7 +910,8 @@ const handleSubmit = async (e: React.FormEvent) => {
     const reservationDate = new Date(`${reservationData.reservation_date}T00:00:00`);
     const dayOfWeek = reservationDate.getDay(); // Domingo = 0, Sexta = 5, Sábado = 6
     const isWeekend = dayOfWeek === 5 || dayOfWeek === 6; // Sexta ou Sábado
-    const isHighLine = payload.establishment_id === 1;
+    const establishmentName = (selectedEstablishment?.name || '').toLowerCase();
+    const isHighLine = establishmentName.includes('high');
 
     // Priorizar o tipo selecionado pelo usuário quando disponível (Highline com mais de 5 pessoas)
     if (isHighLine && payload.number_of_people > 5 && eventType) {


### PR DESCRIPTION
Ensure "Seu Justino" and "Pracinha do Seu Justino" tables appear available when not reserved by replacing hardcoded establishment ID checks with name-based flags.

This change ensures the correct availability logic (resetting `is_reserved` and calculating by time overlap) is always applied to these establishments, regardless of their specific database IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c5690da-c26f-423b-a471-6e95684b2223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c5690da-c26f-423b-a471-6e95684b2223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

